### PR TITLE
Render bar comparison without Recharts

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -16,7 +16,6 @@
       crossorigin
       src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
     ></script>
-    <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body class="bg-gray-100">
@@ -24,15 +23,43 @@
 
     <script type="text/babel">
       const { useState, useEffect } = React;
-      const {
-        BarChart,
-        Bar,
-        XAxis,
-        YAxis,
-        CartesianGrid,
-        Tooltip,
-        ResponsiveContainer,
-      } = Recharts;
+      const BarComparisonChart = ({ data }) => {
+        const maxRate = Math.max(...data.map((item) => item.rate));
+
+        return (
+          <div className="h-64 flex items-end gap-8">
+            {data.map((item) => {
+              const heightPercent =
+                maxRate === 0 ? 0 : Math.round((item.rate / maxRate) * 100);
+
+              return (
+                <div
+                  key={item.name}
+                  className="flex-1 flex flex-col items-center h-full"
+                >
+                  <div className="text-sm font-semibold text-gray-700 mb-2">
+                    {item.rate.toFixed(2)}%
+                  </div>
+                  <div className="flex-1 flex items-end w-full bg-blue-100 rounded-t-lg overflow-hidden">
+                    <div
+                      className="w-full bg-blue-500"
+                      style={{ height: `${heightPercent}%` }}
+                    ></div>
+                  </div>
+                  <div className="mt-3 text-center space-y-1">
+                    <div className="font-semibold text-gray-800">
+                      {item.name}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {item.count} successes / {item.total}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      };
 
       const ABTestingDashboard = () => {
         const [scenario, setScenario] = useState("website");
@@ -70,14 +97,12 @@
           },
         };
 
-        const normalCDF = (x) => 0.5 * (1 + erf(x / Math.sqrt(2)));
-
-        const erf = (x) => {
-          const a1 = 0.254829592;
-          const a2 = -0.284496736;
-          const a3 = 1.421413741;
-          const a4 = -1.453152027;
-          const a5 = 1.061405429;
+      const erf = (x) => {
+        const a1 = 0.254829592;
+        const a2 = -0.284496736;
+        const a3 = 1.421413741;
+        const a4 = -1.453152027;
+        const a5 = 1.061405429;
           const p = 0.3275911;
 
           const sign = x >= 0 ? 1 : -1;
@@ -91,6 +116,8 @@
 
           return sign * y;
         };
+
+      const normalCDF = (x) => 0.5 * (1 + erf(x / Math.sqrt(2)));
 
         const calculatePower = (n1, n2, p1, p2) => {
           const pooledP = (n1 * p1 + n2 * p2) / (n1 + n2);
@@ -175,13 +202,13 @@
         const chartData = [
           {
             name: scenarios[scenario].groupALabel,
-            rate: parseFloat((groupARate * 100).toFixed(2)),
+            rate: groupARate * 100,
             count: Math.round(groupASize * groupARate),
             total: groupASize,
           },
           {
             name: scenarios[scenario].groupBLabel,
-            rate: parseFloat((groupBRate * 100).toFixed(2)),
+            rate: groupBRate * 100,
             count: Math.round(groupBSize * groupBRate),
             total: groupBSize,
           },
@@ -428,30 +455,7 @@
                       <h2 className="text-xl font-semibold mb-4">
                         Visualization
                       </h2>
-                      <div className="h-64">
-                        <ResponsiveContainer width="100%" height="100%">
-                          <BarChart data={chartData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip
-                              formatter={(value, name) => [
-                                name === "rate"
-                                  ? `${value}%`
-                                  : value,
-                                name === "rate"
-                                  ? "Conversion Rate"
-                                  : "Count",
-                              ]}
-                            />
-                            <Bar
-                              dataKey="rate"
-                              fill="#3B82F6"
-                              name="rate"
-                            />
-                          </BarChart>
-                        </ResponsiveContainer>
-                      </div>
+                      <BarComparisonChart data={chartData} />
                     </div>
 
                     <div className="bg-white rounded-lg shadow-lg p-6">


### PR DESCRIPTION
## Summary
- remove the external Recharts UMD script that was blocked by MIME type and CSP errors
- replace the Recharts-based visualization with a lightweight inlined React BarComparisonChart component
- keep the dashboard layout intact while showing rates, counts, and totals without third-party charting dependencies

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cc1b14e6f4832c9dffacb8aa79ebc6