### PR TITLE
Fix Recharts CDN reference

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -18,7 +18,7 @@
     ></script>
     <script
       crossorigin
-      src="https://cdn.jsdelivr.net/npm/recharts@3.2.3/umd/Recharts.min.js"
+      src="https://unpkg.com/recharts@3.2.3/umd/Recharts.min.js"
     ></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>


### PR DESCRIPTION
## Summary
- switch the Recharts script tag from jsDelivr to the unpkg CDN so the bundle loads without CORS or MIME issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc555cd260832c95567231567ae095