### PR TITLE
Align sample dashboard styling with Purdue colors

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -10,7 +10,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='%233b82f6'/%3E%3Ctext x='32' y='40' font-family='Arial' font-size='28' text-anchor='middle' fill='white'%3ES%3C/text%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='%23C28E0E'/%3E%3Ctext x='32' y='40' font-family='Arial' font-size='28' text-anchor='middle' fill='white'%3ES%3C/text%3E%3C/svg%3E"
     />
     <script src="https://cdn.tailwindcss.com"></script>
     <script
@@ -23,7 +23,7 @@
     ></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-  <body class="bg-gray-100">
+  <body class="bg-white">
     <div id="root"></div>
 
     <script type="text/babel">
@@ -31,7 +31,7 @@
       const SimpleBarChart = ({ data, metricLabel }) => {
         if (!data || data.length === 0) {
           return (
-            <div className="flex h-full items-center justify-center text-gray-500">
+            <div className="flex h-full items-center justify-center text-[#9D968D]">
               No data to display
             </div>
           );
@@ -65,18 +65,18 @@
                   >
                     <div className="flex-1 flex items-end w-full">
                       <div
-                        className="w-full rounded-t-lg bg-gradient-to-t from-blue-600 to-blue-400 shadow-lg transition-all duration-300"
+                        className="w-full rounded-t-lg bg-gradient-to-t from-[#C28E0E] to-[#CEB888] shadow-lg transition-all duration-300"
                         style={{ height: `${percentage}%` }}
                       ></div>
                     </div>
                     <div className="mt-3 text-center">
-                      <p className="text-lg font-semibold text-gray-800">
+                      <p className="text-lg font-semibold text-[#000000]">
                         {formattedRate}%
                       </p>
-                      <p className="text-sm text-gray-500">
+                      <p className="text-sm text-[#9D968D]">
                         {item.count} / {item.total}
                       </p>
-                      <p className="text-xs uppercase tracking-wide text-gray-400">
+                      <p className="text-xs uppercase tracking-wide text-[#373A36]">
                         {metricLabel}
                       </p>
                     </div>
@@ -84,7 +84,7 @@
                 );
               })}
             </div>
-            <div className="border-t border-gray-200 mt-4 pt-2 text-center text-sm text-gray-500">
+            <div className="border-t border-[#9D968D] mt-4 pt-2 text-center text-sm text-[#9D968D]">
               Values expressed as percentages
             </div>
           </div>
@@ -246,12 +246,12 @@
 
         const getSignificanceColor = (pValue) => {
           if (pValue < 0.001)
-            return "text-green-700 bg-green-100";
+            return "text-[#000000] bg-[#C28E0E]";
           if (pValue < 0.01)
-            return "text-green-600 bg-green-50";
+            return "text-[#000000] bg-[#CEB888]";
           if (pValue < 0.05)
-            return "text-yellow-700 bg-yellow-100";
-          return "text-red-600 bg-red-50";
+            return "text-[#373A36] bg-white border border-[#C28E0E]";
+          return "text-[#373A36] bg-white border border-[#9D968D]";
         };
 
         const getInterpretation = () => {
@@ -274,12 +274,12 @@
         };
 
         return (
-          <div className="p-6 max-w-7xl mx-auto bg-gray-50 min-h-screen">
-            <div className="bg-white rounded-lg shadow-lg p-6 mb-6">
-              <h1 className="text-3xl font-bold text-gray-800 mb-2">
+          <div className="p-6 max-w-7xl mx-auto bg-white min-h-screen">
+            <div className="bg-white rounded-lg shadow-lg p-6 mb-6 border border-[#9D968D]">
+              <h1 className="text-3xl font-bold text-[#000000] mb-2">
                 A/B Testing Dashboard
               </h1>
-              <p className="text-gray-600">
+              <p className="text-[#373A36]">
                 Interactive statistical learning tool for hypothesis
                 testing
               </p>
@@ -287,19 +287,19 @@
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
               <div className="space-y-6">
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4">
+                <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                  <h2 className="text-xl font-semibold mb-4 text-[#000000]">
                     Test Configuration
                   </h2>
                   <div className="space-y-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         Test Scenario
                       </label>
                       <select
                         value={scenario}
                         onChange={(e) => setScenario(e.target.value)}
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       >
                         {Object.entries(scenarios).map(
                           ([key, value]) => (
@@ -312,7 +312,7 @@
                     </div>
 
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         Significance Level (α)
                       </label>
                       <select
@@ -322,7 +322,7 @@
                             parseFloat(e.target.value)
                           )
                         }
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       >
                         <option value={0.1}>0.10 (10%)</option>
                         <option value={0.05}>0.05 (5%)</option>
@@ -330,24 +330,24 @@
                       </select>
                     </div>
 
-                    <div className="bg-blue-50 p-4 rounded-lg">
-                      <h3 className="font-semibold text-blue-800">
+                    <div className="bg-white border-l-4 border-[#C28E0E] p-4 rounded-lg">
+                      <h3 className="font-semibold text-[#000000]">
                         {scenarios[scenario].title}
                       </h3>
-                      <p className="text-blue-700 text-sm">
+                      <p className="text-[#373A36] text-sm">
                         {scenarios[scenario].description}
                       </p>
                     </div>
                   </div>
                 </div>
 
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4 text-blue-600">
+                <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                  <h2 className="text-xl font-semibold mb-4 text-[#C28E0E]">
                     Group A: {scenarios[scenario].groupALabel}
                   </h2>
                   <div className="space-y-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         Sample Size
                       </label>
                       <input
@@ -360,11 +360,11 @@
                         }
                         min="50"
                         max="10000"
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         {scenarios[scenario].metric} (%)
                       </label>
                       <input
@@ -378,16 +378,16 @@
                         min="0"
                         max="100"
                         step="0.1"
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       />
                     </div>
-                    <div className="bg-blue-50 p-3 rounded">
-                      <p className="text-sm text-blue-700">
+                    <div className="bg-white border-l-4 border-[#C28E0E] p-3 rounded">
+                      <p className="text-sm text-[#373A36]">
                         <strong>Conversions:</strong>{" "}
                         {Math.round(groupASize * groupARate)} out of{" "}
                         {groupASize}
                       </p>
-                      <p className="text-sm text-blue-700">
+                      <p className="text-sm text-[#373A36]">
                         <strong>Rate:</strong>{" "}
                         {(groupARate * 100).toFixed(2)}%
                       </p>
@@ -395,13 +395,13 @@
                   </div>
                 </div>
 
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4 text-green-600">
+                <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                  <h2 className="text-xl font-semibold mb-4 text-[#373A36]">
                     Group B: {scenarios[scenario].groupBLabel}
                   </h2>
                   <div className="space-y-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         Sample Size
                       </label>
                       <input
@@ -414,11 +414,11 @@
                         }
                         min="50"
                         max="10000"
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-[#373A36] mb-2">
                         {scenarios[scenario].metric} (%)
                       </label>
                       <input
@@ -432,16 +432,16 @@
                         min="0"
                         max="100"
                         step="0.1"
-                        className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500"
+                        className="w-full p-3 border border-[#9D968D] rounded-md focus:ring-2 focus:ring-[#C28E0E]"
                       />
                     </div>
-                    <div className="bg-green-50 p-3 rounded">
-                      <p className="text-sm text-green-700">
+                    <div className="bg-white border-l-4 border-[#CEB888] p-3 rounded">
+                      <p className="text-sm text-[#373A36]">
                         <strong>Conversions:</strong>{" "}
                         {Math.round(groupBSize * groupBRate)} out of{" "}
                         {groupBSize}
                       </p>
-                      <p className="text-sm text-green-700">
+                      <p className="text-sm text-[#373A36]">
                         <strong>Rate:</strong>{" "}
                         {(groupBRate * 100).toFixed(2)}%
                       </p>
@@ -449,11 +449,11 @@
                   </div>
                 </div>
 
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4">
+                <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                  <h2 className="text-xl font-semibold mb-4 text-[#000000]">
                     Learning Notes
                   </h2>
-                  <div className="space-y-3 text-sm text-gray-700">
+                  <div className="space-y-3 text-sm text-[#373A36]">
                     <p>
                       <strong>P-Value:</strong> The probability of
                       observing this difference (or more extreme) if
@@ -481,8 +481,8 @@
               <div className="space-y-6">
                 {results && (
                   <>
-                    <div className="bg-white rounded-lg shadow-lg p-6">
-                      <h2 className="text-xl font-semibold mb-4">
+                    <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                      <h2 className="text-xl font-semibold mb-4 text-[#000000]">
                         Visualization
                       </h2>
                       <div className="h-64">
@@ -493,16 +493,16 @@
                       </div>
                     </div>
 
-                    <div className="bg-white rounded-lg shadow-lg p-6">
-                      <h2 className="text-xl font-semibold mb-4">
+                    <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                      <h2 className="text-xl font-semibold mb-4 text-[#000000]">
                         Test Results
                       </h2>
 
                       <div
                         className={`p-4 rounded-lg mb-6 ${
                           results.isSignificant
-                            ? "bg-green-50 border border-green-200"
-                            : "bg-red-50 border border-red-200"
+                            ? "bg-[#CEB888] text-[#000000]"
+                            : "bg-white border border-[#9D968D] text-[#373A36]"
                         }`}
                       >
                         <p className="font-medium text-lg">
@@ -511,11 +511,11 @@
                       </div>
 
                       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div className="bg-gray-50 p-4 rounded-lg text-center">
-                          <h3 className="font-semibold text-gray-700 mb-1">
+                        <div className="bg-white border border-[#9D968D] p-4 rounded-lg text-center">
+                          <h3 className="font-semibold text-[#373A36] mb-1">
                             Z-Statistic
                           </h3>
-                          <p className="text-3xl font-bold text-blue-600">
+                          <p className="text-3xl font-bold text-[#C28E0E]">
                             {results.zStat.toFixed(3)}
                           </p>
                         </div>
@@ -531,55 +531,55 @@
                           </p>
                         </div>
 
-                        <div className="bg-gray-50 p-4 rounded-lg text-center">
-                          <h3 className="font-semibold text-gray-700 mb-1">
+                        <div className="bg-white border border-[#9D968D] p-4 rounded-lg text-center">
+                          <h3 className="font-semibold text-[#373A36] mb-1">
                             Effect Size
                           </h3>
-                          <p className="text-3xl font-bold text-purple-600">
+                          <p className="text-3xl font-bold text-[#C28E0E]">
                             {results.effectSizePercent.toFixed(2)}%
                           </p>
                         </div>
 
-                        <div className="bg-gray-50 p-4 rounded-lg text-center">
-                          <h3 className="font-semibold text-gray-700 mb-1">
+                        <div className="bg-white border border-[#9D968D] p-4 rounded-lg text-center">
+                          <h3 className="font-semibold text-[#373A36] mb-1">
                             Statistical Power
                           </h3>
-                          <p className="text-3xl font-bold text-orange-600">
+                          <p className="text-3xl font-bold text-[#C28E0E]">
                             {(results.power * 100).toFixed(1)}%
                           </p>
                         </div>
                       </div>
                     </div>
 
-                    <div className="bg-white rounded-lg shadow-lg p-6">
-                      <h2 className="text-xl font-semibold mb-4">
+                    <div className="bg-white rounded-lg shadow-lg p-6 border border-[#9D968D]">
+                      <h2 className="text-xl font-semibold mb-4 text-[#000000]">
                         Statistical Details
                       </h2>
 
                       <div className="space-y-4">
-                        <div className="bg-blue-50 p-4 rounded-lg">
-                          <h3 className="font-semibold text-blue-800 mb-2">
+                        <div className="bg-white border-l-4 border-[#C28E0E] p-4 rounded-lg">
+                          <h3 className="font-semibold text-[#000000] mb-2">
                             Hypothesis Test Setup
                           </h3>
-                          <p className="text-blue-700 text-sm">
+                          <p className="text-[#373A36] text-sm">
                             <strong>H₀:</strong> p₁ = p₂ (No difference
                             between groups)
                           </p>
-                          <p className="text-blue-700 text-sm">
+                          <p className="text-[#373A36] text-sm">
                             <strong>H₁:</strong> p₁ ≠ p₂ (There is a
                             difference between groups)
                           </p>
-                          <p className="text-blue-700 text-sm">
+                          <p className="text-[#373A36] text-sm">
                             <strong>Significance Level:</strong> α ={" "}
                             {significanceLevel}
                           </p>
                         </div>
 
-                        <div className="bg-gray-50 p-4 rounded-lg">
-                          <h3 className="font-semibold text-gray-700 mb-2">
+                        <div className="bg-white border border-[#9D968D] p-4 rounded-lg">
+                          <h3 className="font-semibold text-[#373A36] mb-2">
                             Confidence Interval (95%)
                           </h3>
-                          <p className="text-gray-700 text-sm">
+                          <p className="text-[#373A36] text-sm">
                             The true difference is likely between{" "}
                             <strong>
                               {results.ciLower.toFixed(2)}%
@@ -591,31 +591,31 @@
                           </p>
                           {results.ciLower <= 0 &&
                             results.ciUpper >= 0 && (
-                              <p className="text-orange-600 mt-1 text-sm">
+                              <p className="text-[#C28E0E] mt-1 text-sm">
                                 ⚠️ The confidence interval includes 0,
                                 suggesting no significant difference.
                               </p>
                             )}
                         </div>
 
-                        <div className="bg-yellow-50 p-4 rounded-lg">
-                          <h3 className="font-semibold text-yellow-800 mb-2">
+                        <div className="bg-white border border-[#CEB888] p-4 rounded-lg">
+                          <h3 className="font-semibold text-[#000000] mb-2">
                             Key Metrics
                           </h3>
                           <div className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-                            <p className="text-yellow-700">
+                            <p className="text-[#373A36]">
                               <strong>Pooled Proportion:</strong>{" "}
                               {(results.pooledP * 100).toFixed(2)}%
                             </p>
-                            <p className="text-yellow-700">
+                            <p className="text-[#373A36]">
                               <strong>Standard Error:</strong>{" "}
                               {results.se.toFixed(4)}
                             </p>
-                            <p className="text-yellow-700">
+                            <p className="text-[#373A36]">
                               <strong>Group A Rate:</strong>{" "}
                               {(results.p1 * 100).toFixed(2)}%
                             </p>
-                            <p className="text-yellow-700">
+                            <p className="text-[#373A36]">
                               <strong>Group B Rate:</strong>{" "}
                               {(results.p2 * 100).toFixed(2)}%
                             </p>


### PR DESCRIPTION
## Summary
- update favicon and overall layout backgrounds to use Purdue brand neutrals
- restyle charts, forms, and metric cards with Campus Gold, Athletic Gold, and Purdue Black accents
- harmonize status messaging and statistical detail panels with gray support tones for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc5e39ecd4832c8a4e884183df4ac7